### PR TITLE
Refactor to show prospect import logs

### DIFF
--- a/UploadedFileList.jsx
+++ b/UploadedFileList.jsx
@@ -3,13 +3,9 @@ import { useCallback, useEffect, useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { format } from "date-fns";
 import { API } from "../../global";
-import {
-  capitalizeIndustry,
-  capitalizeText,
-  formatRevenue,
-} from "../../Constants/Funtions/commonFunctions";
+// Import removed since we're not using company-related functions for upload logs
 import DataTable from "../Reusable/DataTable/DataTable_v2";
-import { companyDatabaseColumnHeader } from "../OutReachDetails/CommonColumnHeadr";
+import { uploadedDataColumnHeader } from "../OutReachDetails/CommonColumnHeadr";
 import CompanyViewDetails from "../OutReachDetails/MarketPlan/CompanyViewDetails";
 import ContactDetails from "../OutReachDetails/MarketPlan/ContactDetails";
 
@@ -19,7 +15,6 @@ const UploadedFileList = () => {
   // State management
   const [allUploadDetails, setAllUploadDetails] = useState([]); // Store all upload data from server
   const [isLoading, setIsLoading] = useState(false);
-  const [userDetails, setUserListDetails] = useState([]);
   const [initialLoadComplete, setInitialLoadComplete] = useState(false);
 
   // URL parameters
@@ -142,12 +137,9 @@ const UploadedFileList = () => {
   );
 
   // Memoize table columns to prevent unnecessary re-renders
-  // Note: You'll need to create appropriate column headers for upload logs
   const tableColumns = useMemo(() => {
-    // You might want to create a new column header function for upload logs
-    // or modify the existing one to handle upload data
-    return companyDatabaseColumnHeader(userDetails, allUploadDetails);
-  }, [userDetails, allUploadDetails]);
+    return uploadedDataColumnHeader(handleReadMore, "uploaded_files");
+  }, [handleReadMore]);
 
   // Show loading state for initial load
   if (!initialLoadComplete && isLoading) {


### PR DESCRIPTION
Refactor `UploadedFileList` component to display prospect import logs instead of company data.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-0edf8c75-ec76-4e04-9382-516708221e7f) · [Cursor](https://cursor.com/background-agent?bcId=bc-0edf8c75-ec76-4e04-9382-516708221e7f)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)